### PR TITLE
Move generation selector

### DIFF
--- a/app/assets/stylesheets/generation_dropdown.scss
+++ b/app/assets/stylesheets/generation_dropdown.scss
@@ -1,0 +1,42 @@
+#generation-dropdown {
+  $button-size: 50px;
+  $width: 2;
+  $height: 4;
+
+  // Override Materialize size
+  width: fit-content;
+  height: fit-content;
+
+  .generation-widget {
+    .title {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+
+      height: 25px;
+
+      font-size: 11px;
+      color: grey;
+      text-transform: uppercase;
+    }
+
+    hr {
+      color: #efefef;
+      margin: 0 3px;
+    }
+
+    .buttons {
+      display: grid;
+      grid-template-columns: repeat($width, $button-size);
+      grid-template-rows: repeat($height, $button-size);
+
+      list-style-type: none;
+
+      li {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/search_bar.scss
+++ b/app/assets/stylesheets/search_bar.scss
@@ -33,7 +33,7 @@
   overflow-x: hidden;
   max-width: 60em;
 
-  h6:not(.no-bottom-margin) {
+  h6 {
     margin-bottom: 1rem;
   }
 

--- a/app/assets/stylesheets/search_bar.scss
+++ b/app/assets/stylesheets/search_bar.scss
@@ -9,16 +9,23 @@
     flex: 1;
   }
 
-  #filters-btn {
-    width: 2.25rem;
-    height: 2.25rem;
-    i {
-      font-size: 1.5rem;
-    }
+  .search-bar-buttons {
+    display: inherit;
+    align-items: inherit;
+    gap: inherit;
 
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    a {
+      width: 2.25rem;
+      height: 2.25rem;
+
+      i {
+        font-size: 1.5rem;
+      }
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
   }
 }
 

--- a/app/javascript/controllers/form_submission_controller.js
+++ b/app/javascript/controllers/form_submission_controller.js
@@ -1,5 +1,6 @@
 import { Controller } from "@hotwired/stimulus"
 
+// Connects to data-controller="form-submission"
 export default class extends Controller {
     searchSubmit() {
         clearTimeout(this.timeout);
@@ -8,21 +9,5 @@ export default class extends Controller {
 
     submit() {
         event.target.closest("form").requestSubmit();
-    }
-
-    // This select (in the filters modal) just sets a cookie and refreshes the form
-    generationSubmit() {
-        const gen = parseInt(document.getElementById("generation").value);
-
-        // If a gen is selected, permanent cookie. Otherwise delete any existing cookie
-        const expire_date = gen ? new Date(Date.now() + (20 * 365 * 24 * 60 * 60 * 1000))
-                                : new Date(0);
-
-        document.cookie = `generation=${gen}; path=/; SameSite=Lax; expires=${expire_date}`;
-
-        M.Modal.getInstance(document.getElementById("species-filters")).close();
-
-        // Reload entire page, this way we update the tooltips, etc.
-        Turbo.visit(window.location.href, {action: "replace"});
     }
 }

--- a/app/javascript/controllers/generation_widget_controller.js
+++ b/app/javascript/controllers/generation_widget_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="generation-widget"
+export default class extends Controller {
+    // This just sets a cookie and refreshes the page
+    submit(event) {
+        const gen = parseInt(event.currentTarget.innerText.trim());
+
+        // If a gen is selected, permanent cookie. Otherwise delete any existing cookie
+        const expire_date = gen ? new Date(Date.now() + (20 * 365 * 24 * 60 * 60 * 1000))
+                                : new Date(0);
+
+        document.cookie = `generation=${gen}; path=/; SameSite=Lax; expires=${expire_date}`;
+
+        // Reload entire page, this way we update the tooltips, etc.
+        Turbo.visit(window.location.href, {action: "replace"});
+    }
+}

--- a/app/javascript/dropdown_init.js
+++ b/app/javascript/dropdown_init.js
@@ -1,0 +1,3 @@
+runOnLoad(() => {
+    M.Dropdown.init(document.querySelectorAll(".dropdown-trigger"));
+});

--- a/app/javascript/generation_dropdown.js
+++ b/app/javascript/generation_dropdown.js
@@ -1,0 +1,3 @@
+runOnLoad(() => {
+    M.Dropdown.getInstance(document.querySelector("#generation-btn")).options.alignment = "right"
+});

--- a/app/javascript/update_evs.js
+++ b/app/javascript/update_evs.js
@@ -5,7 +5,10 @@ function getInputSum(traineeInfo, klass) {
 
 // Trainee UI behaves as 9th gen if none is selected. This doesn't affect search results.
 function getGeneration() {
-    return parseInt(document.getElementById("generation").value || 9);
+    const generationCookie = document.cookie.split("; ")
+                                            .find(row => row.startsWith("generation="))
+                                            ?.split("=")[1];
+    return parseInt(generationCookie) || 9;
 }
 
 // Returns the item(s) associated with the held item for a given trainee

--- a/app/views/species/_search_bar.haml
+++ b/app/views/species/_search_bar.haml
@@ -10,8 +10,12 @@
     = f.label :q, "Search"
     = f.text_field :q, value: params[:q],
                        data: { action: "input->form-submission#searchSubmit" }
-  %a#filters-btn.btn.waves-effect.grey{onclick:"openModal('species-filters')"}
-    %i.material-icons settings
+  .search-bar-buttons
+    %a#generation-btn.btn.waves-effect.grey
+      %i.material-icons filter_#{cookies[:generation] || "none"}
+    %a#filters-btn.btn.waves-effect.grey{onclick:"openModal('species-filters')"}
+      %i.material-icons filter_alt
+
   #species-filters.modal
     .modal-content
       %h4 Filters

--- a/app/views/species/_search_bar.haml
+++ b/app/views/species/_search_bar.haml
@@ -34,14 +34,6 @@
     .modal-content
       %h4 Filters
 
-      %h6.no-bottom-margin Generation:
-      - generation_options = [["None", nil]] + (3..9).map { |n| [n.to_s] * 2 }
-      -# Dummy form attribute keeps this from showing as a query parameter;
-      -# this feature uses cookies only.
-      = select_tag "generation", options_for_select(generation_options,
-          selected: generation_options.find { |o| o.last == cookies[:generation] }),
-        "data-action": "change->form-submission#generationSubmit", form: "dummy"
-
       %h6 EVs yielded:
       #evs-yielded-filters
         .checkboxes

--- a/app/views/species/_search_bar.haml
+++ b/app/views/species/_search_bar.haml
@@ -23,10 +23,12 @@
     .generation-widget
       .title Generation
       %hr
-      .buttons
+      .buttons{}
         - (3..9).each do |gen|
-          %li{class: "gen#{gen}"}= gen
-        %li.gen-all All
+          %li{class: "gen#{gen}", data: { controller: "generation-widget",
+                                          action: "click->generation-widget#submit" }}= gen
+        %li.gen-all{data: { controller: "generation-widget",
+                            action: "click->generation-widget#submit" }} All
 
   #species-filters.modal
     .modal-content

--- a/app/views/species/_search_bar.haml
+++ b/app/views/species/_search_bar.haml
@@ -1,6 +1,9 @@
-= javascript_include_tag "nouislider.min.js"
 = javascript_include_tag "amount_yielded_slider"
+= javascript_include_tag "dropdown_init"
 = javascript_include_tag "filters"
+= javascript_include_tag "generation_dropdown"
+
+= javascript_include_tag "nouislider.min.js"
 
 = form_with url: request.path, method: :get, class: "species-search",
             data: { controller: "form-submission",
@@ -11,10 +14,19 @@
     = f.text_field :q, value: params[:q],
                        data: { action: "input->form-submission#searchSubmit" }
   .search-bar-buttons
-    %a#generation-btn.btn.waves-effect.grey
+    %a#generation-btn.btn.waves-effect.grey.dropdown-trigger{"data-target": "generation-dropdown"}
       %i.material-icons filter_#{cookies[:generation] || "none"}
     %a#filters-btn.btn.waves-effect.grey{onclick:"openModal('species-filters')"}
       %i.material-icons filter_alt
+
+  #generation-dropdown.dropdown-content
+    .generation-widget
+      .title Generation
+      %hr
+      .buttons
+        - (3..9).each do |gen|
+          %li{class: "gen#{gen}"}= gen
+        %li.gen-all All
 
   #species-filters.modal
     .modal-content

--- a/spec/features/generations_spec.rb
+++ b/spec/features/generations_spec.rb
@@ -16,6 +16,8 @@ RSpec.feature "generations:", type: :feature, js: true do
     # Basic funtionality tests to ensure that a feature isn't broken in any generation
     (3..9).each do |gen|
       context "generation #{gen}:" do
+        before { set_generation gen }
+
         it "kill buttons work" do
           fill_in "Search", with: "Shellder" # 1 Def
           find("#species_090").click

--- a/spec/features/support/generations_spec_helpers.rb
+++ b/spec/features/support/generations_spec_helpers.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
 def set_generation(gen)
-  find("#filters-btn").click
-  find("#species-filters .select-wrapper").hover_and_click
-  find("span", text: gen.to_s).hover_and_click
+  find("#generation-btn").click
+  find(".generation-widget .gen#{gen}").hover_and_click
   sleep 0.5
 end
 


### PR DESCRIPTION
I've decided to go with a widget next to the filters button, like this:
![2023-06-13-004258_1664x132_scrot](https://github.com/vinnydiehl/pokelog/assets/1045694/7b8de1da-5e0a-49aa-936b-f253802f5cdf)
![2023-06-13-130937_160x328_scrot](https://github.com/vinnydiehl/pokelog/assets/1045694/15ee800e-c560-427e-b11b-fb0cab9d1bcb)

closes #42